### PR TITLE
First bar no longer cut in half

### DIFF
--- a/audiovisualizer/src/main/java/com/chibde/visualizer/BarVisualizer.java
+++ b/audiovisualizer/src/main/java/com/chibde/visualizer/BarVisualizer.java
@@ -81,10 +81,11 @@ public class BarVisualizer extends BaseVisualizer {
             paint.setStrokeWidth(barWidth - gap);
 
             for (int i = 0; i < density; i++) {
-                int x = (int) Math.ceil(i * div);
+                int bytePosition = (int) Math.ceil(i * div);
                 int top = canvas.getHeight() +
-                        ((byte) (Math.abs(bytes[x]) + 128)) * canvas.getHeight() / 128;
-                canvas.drawLine(i * barWidth, getHeight(), i * barWidth, top, paint);
+                        ((byte) (Math.abs(bytes[bytePosition]) + 128)) * canvas.getHeight() / 128;
+                float barX = (i * barWidth) + (barWidth / 2);
+                canvas.drawLine(barX, canvas.getHeight(), barX, top, paint);
             }
             super.onDraw(canvas);
         }

--- a/audiovisualizer/src/main/java/com/chibde/visualizer/LineBarVisualizer.java
+++ b/audiovisualizer/src/main/java/com/chibde/visualizer/LineBarVisualizer.java
@@ -91,17 +91,18 @@ public class LineBarVisualizer extends BaseVisualizer {
             paint.setStrokeWidth(barWidth - gap);
 
             for (int i = 0; i < density; i++) {
-                int x = (int) Math.ceil(i * div);
+                int bytePosition = (int) Math.ceil(i * div);
                 int top = canvas.getHeight() / 2
-                        + (128 - Math.abs(bytes[x]))
+                        + (128 - Math.abs(bytes[bytePosition]))
                         * (canvas.getHeight() / 2) / 128;
 
                 int bottom = canvas.getHeight() / 2
-                        - (128 - Math.abs(bytes[x]))
+                        - (128 - Math.abs(bytes[bytePosition]))
                         * (canvas.getHeight() / 2) / 128;
 
-                canvas.drawLine(i * barWidth, bottom, i * barWidth, getHeight() / 2, paint);
-                canvas.drawLine(i * barWidth, top, i * barWidth, getHeight() / 2, paint);
+                float barX = (i * barWidth) + (barWidth / 2);
+                canvas.drawLine(barX, bottom, barX, canvas.getHeight() / 2, paint);
+                canvas.drawLine(barX, top, barX, canvas.getHeight() / 2, paint);
             }
             super.onDraw(canvas);
         }


### PR DESCRIPTION
The first bar was being displayed at x of 0 which meant half of it wasn't seen within the canvas. I changed it to move half a bar width to the right so the first bar fits on the canvas and is displayed the same as all others