### PR TITLE
Clear canvas when visualizer stopped

### DIFF
--- a/audiovisualizer/src/main/java/com/chibde/BaseVisualizer.java
+++ b/audiovisualizer/src/main/java/com/chibde/BaseVisualizer.java
@@ -100,6 +100,8 @@ abstract public class BaseVisualizer extends View {
 
     public void release() {
         visualizer.release();
+        bytes = null;
+        invalidate();
     }
 
     public Visualizer getVisualizer() {


### PR DESCRIPTION
Related to issue #7. Rather than leaving the last shown bars on screen this forces a redraw with no waveform data (so it will look the same as before it started)

Not sure if this is the preferred way to do it as it's changing current behaviour. The alternative would be to provide a seperate method (as mentioned in issue #7 ) to clear the bytes and call invalidate which would achieve the same thing but require the user of this class to control it